### PR TITLE
Use lowercase image name for building docker image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  image-name: ghcr.io/${{ github.repository_owner }}/craftbeerpi4
+  IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/craftbeerpi4
 
 jobs:
   build:
@@ -55,8 +55,11 @@ jobs:
         id: prep
         run: |
 
+          IMAGE_NAME_LOWERCASE=${IMAGE_NAME,,}
+          echo "Using image name $IMAGE_NAME_LOWERCASE"
+
           PUBLISH_IMAGE=false
-          TAGS="${{ env.image-name }}:dev"
+          TAGS="$IMAGE_NAME_LOWERCASE:dev"
 
           # Define the image that will be used as a cached image
           # to speed up the build process
@@ -66,18 +69,21 @@ jobs:
             # when building master/main use :latest tag and the version number
             # from the cbpi/__init__.py file
             VERSION=$(grep -o -E "(([0-9]{1,2}[.]?){2,3}[0-9]+)" cbpi/__init__.py)
-            LATEST_IMAGE=${{ env.image-name }}:latest
+            LATEST_IMAGE=$IMAGE_NAME_LOWERCASE:latest
             BUILD_CACHE_IMAGE_NAME=${LATEST_IMAGE}
-            TAGS="${LATEST_IMAGE},${{ env.image-name }}:v${VERSION}"
-            PUBLISH_IMAGE=true
+            TAGS="${LATEST_IMAGE},$IMAGE_NAME_LOWERCASE:v${VERSION}"
+            PUBLISH_IMAGE="true"
           elif [[ $GITHUB_REF_NAME == development ]]; then
-            PUBLISH_IMAGE=true
+            PUBLISH_IMAGE="true"
           fi
 
-          # Set output parameters.
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=publish_image::${PUBLISH_IMAGE}
-          echo ::set-output name=build_cache_image_name::${BUILD_CACHE_IMAGE_NAME}
+
+          echo "tags: $TAGS"
+          echo "publish_image: $PUBLISH_IMAGE"
+          echo "cache_name: $BUILD_CACHE_IMAGE_NAME"
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "publish_image=$PUBLISH_IMAGE" >> $GITHUB_OUTPUT
+          echo "cache_name=$BUILD_CACHE_IMAGE_NAME" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
@@ -89,23 +95,23 @@ jobs:
         uses: docker/setup-buildx-action@master
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           target: deploy
-          push: ${{ steps.prep.outputs.publish_image }}
+          push: ${{ steps.prep.outputs.publish_image == 'true' }}
           tags: ${{ steps.prep.outputs.tags }}
-          cache-from: type=registry,ref=${{ steps.prep.outputs.build_cache_image_name }}
+          cache-from: type=registry,ref=${{ steps.prep.outputs.cache_name }}
           cache-to: type=inline
           labels: |
             org.opencontainers.image.title=${{ github.event.repository.name }}


### PR DESCRIPTION
Use lowercase naming for docker image build in PiBrewing (and other forks containing uppercase names).

fixes #95