### PR TITLE
Hookable log data revisited

### DIFF
--- a/cbpi/controller/log_file_controller.py
+++ b/cbpi/controller/log_file_controller.py
@@ -42,9 +42,9 @@ class LogController:
         except:
             self.logger.error("Failed to remove listener {}".format(listener_id))
 
-    async def _call_sensor_data_listeners(self, id, value, formatted_time, name):
-        for id, method in self.sensor_data_listeners.items():
-            asyncio.create_task(method(self.cbpi, id, value, formatted_time, name))
+    async def _call_sensor_data_listeners(self, sensor_id, value, formatted_time, name):
+        for listener_id, method in self.sensor_data_listeners.items():
+            asyncio.create_task(method(self.cbpi, sensor_id, value, formatted_time, name))
 
     def log_data(self, id: str, value: str) -> None:        
         # all plugin targets:

--- a/cbpi/extension/ConfigUpdate/__init__.py
+++ b/cbpi/extension/ConfigUpdate/__init__.py
@@ -205,7 +205,7 @@ class ConfigUpdate(CBPiExtension):
         if logfiles is None:
             logger.info("INIT CSV logfiles")
             try:
-                await self.cbpi.config.add("CSVLOGFILES", "Yes", ConfigType.SELECT, "Write sensor data to csv logfiles", 
+                await self.cbpi.config.add("CSVLOGFILES", "Yes", ConfigType.SELECT, "Write sensor data to csv logfiles (enabling requires restart)", 
                                                                                                 [{"label": "Yes", "value": "Yes"},
                                                                                                 {"label": "No", "value": "No"}])
             except:
@@ -215,7 +215,7 @@ class ConfigUpdate(CBPiExtension):
         if influxdb is None:
             logger.info("INIT Influxdb")
             try:
-                await self.cbpi.config.add("INFLUXDB", "No", ConfigType.SELECT, "Write sensor data to influxdb", 
+                await self.cbpi.config.add("INFLUXDB", "No", ConfigType.SELECT, "Write sensor data to influxdb (enabling requires restart)", 
                                                                                                 [{"label": "Yes", "value": "Yes"},
                                                                                                 {"label": "No", "value": "No"}])
             except:

--- a/cbpi/extension/SensorLogTarget_CSV/__init__.py
+++ b/cbpi/extension/SensorLogTarget_CSV/__init__.py
@@ -1,0 +1,52 @@
+
+# -*- coding: utf-8 -*-
+import os
+from logging.handlers import RotatingFileHandler
+import logging
+from unittest.mock import MagicMock, patch
+import asyncio
+import random
+from cbpi.api import *
+from cbpi.api.config import ConfigType
+import urllib3
+import base64
+
+logger = logging.getLogger(__name__)
+
+class SensorLogTargetCSV(CBPiExtension):
+
+    def __init__(self, cbpi): # called from cbpi on start
+        self.cbpi = cbpi
+        self.datalogger = {}
+        self.logfiles = self.cbpi.config.get("CSVLOGFILES", "Yes")
+        if self.logfiles == "No":
+            return # never run()
+        self._task = asyncio.create_task(self.run()) # one time run() only
+
+
+    async def run(self): # called by __init__ once on start if CSV is enabled
+        self.listener_ID = self.cbpi.log.add_sensor_data_listener(self.log_data_to_CSV)
+        logger.info("CSV sensor log target listener ID: {}".format(self.listener_ID))
+
+    async def log_data_to_CSV(self, cbpi, id:str, value:str, formatted_time, name): # called by log_data() hook from the log file controller
+        self.logfiles = self.cbpi.config.get("CSVLOGFILES", "Yes")
+        if self.logfiles == "No":
+            # We intentionally do not unsubscribe the listener here because then we had no way of resubscribing him without a restart of cbpi
+            # as long as cbpi was STARTED with CSVLOGFILES set to Yes this function is still subscribed, so changes can be made on the fly.
+            # but after initially enabling this logging target a restart is required.
+            return
+        if id not in self.datalogger:
+            max_bytes = int(self.cbpi.config.get("SENSOR_LOG_MAX_BYTES", 100000))
+            backup_count = int(self.cbpi.config.get("SENSOR_LOG_BACKUP_COUNT", 3))
+
+            data_logger = logging.getLogger('cbpi.sensor.%s' % id)
+            data_logger.propagate = False
+            data_logger.setLevel(logging.DEBUG)
+            handler = RotatingFileHandler(os.path.join(self.logsFolderPath, f"sensor_{id}.log"), maxBytes=max_bytes, backupCount=backup_count)
+            data_logger.addHandler(handler)
+            self.datalogger[id] = data_logger
+
+        self.datalogger[id].info("%s,%s" % (formatted_time, str(value)))
+
+def setup(cbpi):
+    cbpi.plugin.register("SensorLogTargetCSV", SensorLogTargetCSV)

--- a/cbpi/extension/SensorLogTarget_CSV/__init__.py
+++ b/cbpi/extension/SensorLogTarget_CSV/__init__.py
@@ -42,7 +42,7 @@ class SensorLogTargetCSV(CBPiExtension):
             data_logger = logging.getLogger('cbpi.sensor.%s' % id)
             data_logger.propagate = False
             data_logger.setLevel(logging.DEBUG)
-            handler = RotatingFileHandler(os.path.join(self.logsFolderPath, f"sensor_{id}.log"), maxBytes=max_bytes, backupCount=backup_count)
+            handler = RotatingFileHandler(os.path.join(self.cbpi.log.logsFolderPath, f"sensor_{id}.log"), maxBytes=max_bytes, backupCount=backup_count)
             data_logger.addHandler(handler)
             self.datalogger[id] = data_logger
 

--- a/cbpi/extension/SensorLogTarget_CSV/config.yaml
+++ b/cbpi/extension/SensorLogTarget_CSV/config.yaml
@@ -1,0 +1,3 @@
+name: SensorLogTargetCSV
+version: 4
+active: true

--- a/cbpi/extension/SensorLogTarget_InfluxDB/__init__.py
+++ b/cbpi/extension/SensorLogTarget_InfluxDB/__init__.py
@@ -62,6 +62,8 @@ class SensorLogTargetInfluxDB(CBPiExtension):
                 header = {'User-Agent': id, 'Authorization': "Token {}".format(self.influxdbpwd)}
                 http = PoolManager(timeout=timeout)
                 req = http.request('POST',self.influxdburl, body=out.encode(), headers = header)
+                if req.status != 204:
+                    raise Exception(f'InfluxDB Status code {req.status}')
             except Exception as e:
                 logging.error("InfluxDB cloud write Error: {}".format(e))
 
@@ -72,6 +74,8 @@ class SensorLogTargetInfluxDB(CBPiExtension):
                 header = {'User-Agent': id, 'Content-Type': 'application/x-www-form-urlencoded','Authorization': 'Basic %s' % self.base64string.decode('utf-8')}
                 http = PoolManager(timeout=timeout)
                 req = http.request('POST',self.influxdburl, body=out.encode(), headers = header)
+                if req.status != 204:
+                    raise Exception(f'InfluxDB Status code {req.status}')
             except Exception as e:
                 logging.error("InfluxDB write Error: {}".format(e))
 

--- a/cbpi/extension/SensorLogTarget_InfluxDB/__init__.py
+++ b/cbpi/extension/SensorLogTarget_InfluxDB/__init__.py
@@ -1,0 +1,78 @@
+
+# -*- coding: utf-8 -*-
+import os
+from urllib3 import Timeout, PoolManager
+import logging
+from unittest.mock import MagicMock, patch
+import asyncio
+import random
+from cbpi.api import *
+from cbpi.api.config import ConfigType
+import urllib3
+import base64
+
+logger = logging.getLogger(__name__)
+
+# ToDo:
+# - make log_data(id, value) to use id explicitly so there is no abiguity
+# - create data legend for listener method call parameters including id, value, timestamp, name, cleanname
+# - clean up data preperations for universal use
+# - move influxDB logic to the plugin
+# - 
+
+class SensorLogTargetInfluxDB(CBPiExtension):
+
+    def __init__(self, cbpi): # called from cbpi on start
+        self.cbpi = cbpi
+        self.influxdb = self.cbpi.config.get("INFLUXDB", "No")
+        if self.influxdb == "No":
+            return # never run()
+        self._task = asyncio.create_task(self.run()) # one time run() only
+
+
+    async def run(self): # called by __init__ once on start if influx is enabled
+        self.listener_ID = self.cbpi.log.add_sensor_data_listener(self.log_data_to_InfluxDB)
+        logger.info("InfluxDB sensor log target listener ID: {}".format(self.listener_ID))
+
+    async def log_data_to_InfluxDB(self, cbpi, id:str, value:str, timestamp, name): # called by log_data() hook from the log file controller
+        self.influxdb = self.cbpi.config.get("INFLUXDB", "No")
+        if self.influxdb == "No":
+            # We intentionally do not unsubscribe the listener here because then we had no way of resubscribing him without a restart of cbpi
+            # as long as cbpi was STARTED with INFLUXDB set to Yes this function is still subscribed, so changes can be made on the fly.
+            return
+        self.influxdbcloud = self.cbpi.config.get("INFLUXDBCLOUD", "No")
+        self.influxdbaddr = self.cbpi.config.get("INFLUXDBADDR", None)
+        self.influxdbname = self.cbpi.config.get("INFLUXDBNAME", None)
+        self.influxdbuser = self.cbpi.config.get("INFLUXDBUSER", None)
+        self.influxdbpwd = self.cbpi.config.get("INFLUXDBPWD", None)
+        self.influxdbmeasurement = self.cbpi.config.get("INFLUXDBMEASUREMENT", "measurement")
+        timeout = Timeout(connect=5.0, read=None)
+        try:
+            sensor=self.cbpi.sensor.find_by_id(id)
+            if sensor is not None:
+                itemname=sensor.name.replace(" ", "_")
+                out=str(self.influxdbmeasurement)+",source=" + itemname + ",itemID=" + str(id) + " value="+str(value)
+        except Exception as e:
+            logging.error("InfluxDB ID Error: {}".format(e))
+
+        if self.influxdbcloud == "Yes":
+            self.influxdburl=self.influxdbaddr + "/api/v2/write?org=" + self.influxdbuser + "&bucket=" + self.influxdbname + "&precision=s"
+            try:
+                header = {'User-Agent': id, 'Authorization': "Token {}".format(self.influxdbpwd)}
+                http = PoolManager(timeout=timeout)
+                req = http.request('POST',self.influxdburl, body=out.encode(), headers = header)
+            except Exception as e:
+                logging.error("InfluxDB cloud write Error: {}".format(e))
+
+        else:
+            self.base64string = base64.b64encode(('%s:%s' % (self.influxdbuser,self.influxdbpwd)).encode())
+            self.influxdburl= self.influxdbaddr + '/write?db=' + self.influxdbname
+            try:
+                header = {'User-Agent': id, 'Content-Type': 'application/x-www-form-urlencoded','Authorization': 'Basic %s' % self.base64string.decode('utf-8')}
+                http = PoolManager(timeout=timeout)
+                req = http.request('POST',self.influxdburl, body=out.encode(), headers = header)
+            except Exception as e:
+                logging.error("InfluxDB write Error: {}".format(e))
+
+def setup(cbpi):
+    cbpi.plugin.register("SensorLogTargetInfluxDB", SensorLogTargetInfluxDB)

--- a/cbpi/extension/SensorLogTarget_InfluxDB/__init__.py
+++ b/cbpi/extension/SensorLogTarget_InfluxDB/__init__.py
@@ -39,6 +39,7 @@ class SensorLogTargetInfluxDB(CBPiExtension):
         if self.influxdb == "No":
             # We intentionally do not unsubscribe the listener here because then we had no way of resubscribing him without a restart of cbpi
             # as long as cbpi was STARTED with INFLUXDB set to Yes this function is still subscribed, so changes can be made on the fly.
+            # but after initially enabling this logging target a restart is required.
             return
         self.influxdbcloud = self.cbpi.config.get("INFLUXDBCLOUD", "No")
         self.influxdbaddr = self.cbpi.config.get("INFLUXDBADDR", None)

--- a/cbpi/extension/SensorLogTarget_InfluxDB/config.yaml
+++ b/cbpi/extension/SensorLogTarget_InfluxDB/config.yaml
@@ -1,0 +1,3 @@
+name: SensorLogTargetInfluxDB
+version: 4
+active: true


### PR DESCRIPTION
resolves #60 

for details please read #60 but here is a small summary:

- changes the CSV and InfluxDB logic to act as a core plugin.
- allows new plugins to have access to the same data the current sensor logging logic has

The InfluxDB logging target is implemented like a plugin, somone who wants to implement a new sensor logging target can use this as a reference.

I tested this by creating an influxdb cloud config that was working on the current dev branch. then i checked out my branch and it worked without editing the config parameters. CSV files are created as intended as well. 

this should be tested extensively before merging into master as it changes all logging. I am not usually working with influxdb, if you do and you run this and it is working or not then please report.